### PR TITLE
@Moduledoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ provider which is a tuple of two elements `{GithubAi, :codestral}`.
 
 ## Roadmap
 
-- Make AI docs for modules as well, `@module_doc`.
 - Inspect the `defimpl` and `defprotocol` nodes.
 - Customizable number of retries.
 - Custom paramters to pass the model (max\_tokens, top\_p, temperature).
-- Run mix format after writing the files, just in case.
 
 ## Installation
 
@@ -30,6 +28,9 @@ end
 ``` elixir
 ## alias of GithubAi above
 config :lazy_doc, :provider, {GithubAi, :gpt_4o_mini}
+
+## configure formatter.
+config :lazy_doc, :line_length, 98
 
 config :lazy_doc,
        :custom_function_prompt,

--- a/README.md
+++ b/README.md
@@ -7,9 +7,25 @@ provider which is a tuple of two elements `{GithubAi, :codestral}`.
 
 ## Roadmap
 
-- Inspect the `defimpl` and `defprotocol` nodes.
-- Customizable number of retries.
-- Custom paramters to pass the model (max\_tokens, top\_p, temperature).
+- [X] Make AI docs for functions `@doc`.
+- [X] Simple check if the response is in `@doc` format.
+- [X] Make AI providers more extensible (define a behavior, what an AI provider
+  should do ?).
+- [X] Custom path wildcard (limits the action of `lazy_doc`)
+- [X] Make some unit tests.
+- [X] Improve the default prompt to generate markdown syntax.
+- [X] Fix inner module detection (creates scopes for inner modules and builds
+  the full name of the inner module).
+- [X] Make a task or an arg in the current task to check if the functions are
+  documented. (allows CI usage)
+- [X] File is written to file according to Elixir formatter.
+- [X] Make AI docs for modules as well, `@moduledoc`.
+- [X] Custom prompts for function and module.
+- [ ] Simple check if the response is in `@moduledoc` format.
+- [ ] Customizable number of retries.
+- [ ] Custom paramters to pass the provider (max\_tokens, top\_p, temperature).
+- [ ] Check if custom paramters are valid for that provider.
+- [ ] Inspect the `defimpl` and `defprotocol` nodes.
 
 ## Installation
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,6 @@ config :lazy_doc,
 
 config :lazy_doc,
        :custom_module_prompt,
-       ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc."""\n\nModule to document:\n)
+       ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc.\n"""\n\nModule to document:\n)
 
 config :lazy_doc, :path_wildcard, "lib/**/*.ex"

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,4 +16,8 @@ config :lazy_doc,
        :custom_function_prompt,
        ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n@doc """\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\n"""\n\nFunction to document:\n)
 
+config :lazy_doc,
+       :custom_module_prompt,
+       ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc."""\n\nModule to document:\n)
+
 config :lazy_doc, :path_wildcard, "lib/**/*.ex"

--- a/lib/lazy_doc.ex
+++ b/lib/lazy_doc.ex
@@ -1,9 +1,13 @@
 defmodule LazyDoc do
   @moduledoc """
-  Documentation for `LazyDoc`.
 
-  This module is intended to contain shared functions between tasks.
+   ## Main functionality
 
+   The module LazyDoc provides a way to extract and organize documentation from Elixir source files by reading them, parsing their abstract syntax tree (AST), and collecting relevant information about modules, functions, and comments.
+
+   ## Description
+
+   It implements functions to read files matching a given path pattern, extract their AST and comments, group function definitions by names and arities, filter out undocumented functions and modules, and retrieve associated documentation for the extracted modules. The module serves as a utility for generating or managing documentation for Elixir projects.
   """
 
   @doc """
@@ -23,7 +27,7 @@ defmodule LazyDoc do
 
     Path.wildcard(path_wildcard)
     |> Enum.map(fn file ->
-      # this task is for dev purposes so if we do not have a success reading a file is weird.
+      # this task is for dev purposes so if we do not have a success read, it is weird.
       {:ok, content} = File.read(file)
 
       {:ok, ast, comments} =

--- a/lib/lazy_doc/application.ex
+++ b/lib/lazy_doc/application.ex
@@ -1,4 +1,14 @@
 defmodule LazyDoc.Application do
+  @moduledoc """
+
+   ## Main functionality
+
+   The module LazyDoc.Application is responsible for initiating the application process in the LazyDoc system.
+
+   ## Description
+
+   It provides a start function that allows for the initiation of application processes with specified start parameters. The function returns the process identifier of the newly started process, which can be utilized for further interactions within the application.
+  """
   use Application
 
   @doc """

--- a/lib/lazy_doc/provider.ex
+++ b/lib/lazy_doc/provider.ex
@@ -1,4 +1,14 @@
 defmodule LazyDoc.Provider do
+  @moduledoc """
+
+   ## Main functionality
+
+   The module LazyDoc.Provider provides a standard interface for making requests to an external service and processing the responses.
+
+   ## Description
+
+   It defines a set of callbacks and functions that allow a user to request a prompt, retrieve documents from a response, and interact with models, enabling flexible integration with various providers that conform to this interface.
+  """
   @callback request_prompt(prompt :: binary(), model :: binary(), token :: binary()) ::
               {:ok, Req.Response.t()} | {:error, Exception.t()}
 

--- a/lib/lazy_doc/providers/github_ai.ex
+++ b/lib/lazy_doc/providers/github_ai.ex
@@ -1,4 +1,14 @@
 defmodule LazyDoc.Providers.GithubAi do
+  @moduledoc """
+
+   ## Main functionality
+
+   The module LazyDoc.Providers.GithubAi provides a way of interacting with the Github AI API for prompt-based communication and response generation.
+
+   ## Description
+
+   It implements the behavior Provider, offering a standardized method to request and retrieve responses from AI models hosted on the Github AI platform. Key operations include sending prompts, constructing API requests, and processing responses.
+  """
   @behaviour LazyDoc.Provider
 
   @github_ai_endpoint "https://models.github.ai/inference/chat/completions"

--- a/lib/mix/tasks/lazy_doc.check.ex
+++ b/lib/mix/tasks/lazy_doc.check.ex
@@ -1,4 +1,14 @@
 defmodule Mix.Tasks.LazyDoc.Check do
+  @moduledoc """
+
+   ## Main functionality
+
+   The module Mix.Tasks.LazyDoc.Check is designed to facilitate the checking of documentation for functions and modules within a codebase using the LazyDoc application.
+
+   ## Description
+
+   It initializes the LazyDoc application, identifies undocumented functions and modules across specified files, and exits with an appropriate status code based on the presence of undocumented elements. Warnings are logged for any undocumented functions and modules encountered during the check.
+  """
   require Logger
   use Mix.Task
 
@@ -17,12 +27,11 @@ defmodule Mix.Tasks.LazyDoc.Check do
   def run(_command_line_args) do
     _result = LazyDoc.Application.start("", "")
 
-    path_wildcard = Application.get_env(:lazy_doc, :path_wildcard, "lib/**/*.ex")
-
     values =
-      LazyDoc.extract_data_from_files(path_wildcard)
+      LazyDoc.extract_data_from_files()
       |> Enum.map(fn entry ->
-        get_undocumented_functions(entry.functions, entry.file) != []
+        get_undocumented_functions(entry.functions, entry.file) != [] or
+          get_undocumented_modules(entry.modules, entry.file)
       end)
 
     if Enum.any?(values, fn val -> val end) do
@@ -77,5 +86,32 @@ defmodule Mix.Tasks.LazyDoc.Check do
     end)
 
     Logger.info("file: #{file}")
+  end
+
+  @doc """
+
+  ## Parameters
+
+  - modules - a list of modules to check for documentation.
+  - file - the name of the file where the modules are located.
+
+  ## Description
+   Checks if the provided modules are documented and logs warnings for any undocumented modules.
+
+  ## Returns
+   true if there are undocumented modules, false otherwise.
+
+  """
+  def get_undocumented_modules(modules, file) do
+    if modules != [] do
+      Enum.each(modules, fn {mod, _mod_ast, _cod} ->
+        Logger.warning("Module `#{mod}` needs to be documented")
+        Logger.info("file: #{file}")
+      end)
+
+      true
+    else
+      false
+    end
   end
 end

--- a/lib/mix/tasks/lazy_doc.ex
+++ b/lib/mix/tasks/lazy_doc.ex
@@ -16,8 +16,7 @@ defmodule Mix.Tasks.LazyDoc do
 
   @default_function_prompt ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n@doc """\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\n"""\n\nFunction to document:\n)
 
-  ## TO_DO: before closing this PR change this prompt, to @moduledoc
-  @default_module_prompt ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@module """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc."""\n\nModule to document:\n)
+  @default_module_prompt ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc.\n"""\n\nModule to document:\n)
 
   @doc """
 

--- a/lib/mix/tasks/lazy_doc.ex
+++ b/lib/mix/tasks/lazy_doc.ex
@@ -1,10 +1,23 @@
 defmodule Mix.Tasks.LazyDoc do
+  @moduledoc """
+
+   ## Main functionality
+
+   The module Mix.Tasks.LazyDoc provides a Mix task for processing source files to extract and format documentation for Elixir modules and functions.
+
+   ## Description
+
+   It enables the extraction of documentation using AI to enhance the documentation generation process, verifying and formatting documentation as per specified requirements. It handles reading the source code, interacting with a provider for documentation prompts, and writing the results back in a structured format.
+  """
   alias LazyDoc.Provider
 
   require Logger
   use Mix.Task
 
   @default_function_prompt ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n@doc """\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\n"""\n\nFunction to document:\n)
+
+  ## TO_DO: before closing this PR change this prompt, to @moduledoc
+  @default_module_prompt ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@module """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc."""\n\nModule to document:\n)
 
   @doc """
 
@@ -27,20 +40,11 @@ defmodule Mix.Tasks.LazyDoc do
 
     _result = LazyDoc.Application.start("", "")
 
-    {provider_mod, model} = Application.get_env(:lazy_doc, :provider)
-
-    final_prompt =
-      Application.get_env(:lazy_doc, :custom_function_prompt, @default_function_prompt)
-
     ## Runs the runtime.exs from the client
     Mix.Task.run("app.config")
 
-    token = Application.get_env(:lazy_doc, :token)
-
-    path_wildcard = Application.get_env(:lazy_doc, :path_wildcard, "lib/**/*.ex")
-
-    LazyDoc.extract_data_from_files(path_wildcard)
-    |> proccess_files(final_prompt, provider_mod, model, token)
+    LazyDoc.extract_data_from_files()
+    |> proccess_files()
   end
 
   @doc """
@@ -173,32 +177,46 @@ defmodule Mix.Tasks.LazyDoc do
   Description
    A list of entries to process, transforming functions based on model responses.
 
-  final_prompt - a string prefix to be added to each function's prompt.
-  Description
-   The initial text that precedes the function's string representation in the prompt.
-
-  provider_mod - a module responsible for handling requests to the provider.
-  Description
-   The module which encapsulates the logic for interacting with the AI provider's API.
-
-  model - the model identifier used to request AI-generated documentation.
-  Description
-   Specifies which AI model to use for generating the required documentation.
-
-  token - an authorization token for the API requests.
-  Description
-   The security token needed to authenticate requests to the provider's API.
-
   Returns
    None
   """
-  def proccess_files(entries, final_prompt, provider_mod, model, token) do
+  def proccess_files(entries) do
+    {provider_mod, model} = Application.get_env(:lazy_doc, :provider)
+
+    final_function_prompt =
+      Application.get_env(:lazy_doc, :custom_function_prompt, @default_function_prompt)
+
+    final_module_prompt =
+      Application.get_env(:lazy_doc, :custom_module_prompt, @default_module_prompt)
+
+    token = Application.get_env(:lazy_doc, :token)
+
     model_text = Provider.model(provider_mod, model)
 
     Enum.each(entries, fn entry ->
       acc =
-        Enum.reduce(entry.functions, entry.ast, fn mod_tuple, acc ->
-          insert_nodes_in_module(mod_tuple, final_prompt, provider_mod, model_text, token, acc)
+        Enum.reduce(entry.modules, entry.ast, fn {_mod, mod_ast, code_mod}, acc_ast ->
+          function_prompt = final_module_prompt <> code_mod
+          ## TO_DO: probably we should something here instead of just doing :ok
+          {:ok, response} =
+            Provider.request_prompt(provider_mod, function_prompt, model_text, token)
+
+          docs = Provider.get_docs_from_response(provider_mod, response)
+
+          # TO_DO: check if the @module_doc is ok
+          docs_to_module_doc_node(docs, acc_ast, mod_ast)
+        end)
+
+      acc =
+        Enum.reduce(entry.functions, acc, fn mod_tuple, acc_ast ->
+          insert_nodes_in_module(
+            mod_tuple,
+            final_function_prompt,
+            provider_mod,
+            model_text,
+            token,
+            acc_ast
+          )
         end)
 
       # TO_DO: probably we should check if the ast_acc is the same as entry.ast
@@ -276,5 +294,90 @@ defmodule Mix.Tasks.LazyDoc do
     Logger.error(
       "docs are in a wrong format review your prompt\n\n this was returned by the AI: #{docs}"
     )
+  end
+
+  @doc """
+
+  ## Parameters
+
+  - docs - the documentation string to be converted to an abstract syntax tree (AST).
+  - acc_ast - the accumulator AST to which the new documentation will be added.
+  - module_ast - the AST of the module where the documentation will be inserted.
+
+  ## Description
+   Converts a documentation string into an Elixir AST and inserts it into the specified module's AST.
+
+  ## Returns
+   the updated accumulator AST after inserting the new documentation.
+  """
+  def docs_to_module_doc_node(docs, acc_ast, module_ast) do
+    result =
+      Code.string_to_quoted_with_comments(docs,
+        literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+        token_metadata: true,
+        unescape: false
+      )
+
+    case result do
+      {:ok, node, _} ->
+        insert_module_doc(acc_ast, module_ast, node)
+
+      {:error, reason} ->
+        Logger.error("Cannot parse the response as an Elixir AST: #{inspect(reason)}")
+        acc_ast
+    end
+  end
+
+  @doc """
+
+  ## Parameters
+
+  - ast - the Abstract Syntax Tree (AST) representing the module structure.
+  - module_ast - the AST representation of the specific module to be modified.
+  - ast_doc - a documentation string or AST node to be inserted into the module.
+
+  ## Description
+  Inserts documentation into a specified module in the AST by traversing and modifying the module's structure.
+
+  ## Returns
+  The modified AST with the new documentation inserted.
+
+  """
+  def insert_module_doc(ast, module_ast, ast_doc) do
+    {new_ast, _acc} =
+      Macro.prewalk(
+        ast,
+        [],
+        fn
+          {:defmodule, meta_mod,
+           [
+             {:__aliases__, _meta_aliases, ^module_ast} = aliases_node,
+             [{{:__block__, meta_block, [:do]}, {:__block__, meta_inner_block, block_children}}]
+           ]},
+          acc ->
+            new_do_block = [
+              {{:__block__, meta_block, [:do]},
+               {:__block__, meta_inner_block, [ast_doc | block_children]}}
+            ]
+
+            {{:defmodule, meta_mod, [aliases_node, new_do_block]}, [:complex_mod | acc]}
+
+          # Single node module
+          {:defmodule, meta_mod,
+           [
+             {:__aliases__, _meta_aliases, ^module_ast} = aliases_node,
+             [{{:__block__, meta_block, [:do]}, node}]
+           ]} = _ast,
+          acc ->
+            new_do_block = [{{:__block__, meta_block, [:do]}, {:__block__, [], [ast_doc, node]}}]
+
+            {{:defmodule, meta_mod, [aliases_node, new_do_block]}, [:simple_mod | acc]}
+
+          other, acc ->
+            {other, acc}
+        end
+      )
+
+    new_ast
   end
 end

--- a/test/lazy_doc/task_test.exs
+++ b/test/lazy_doc/task_test.exs
@@ -28,7 +28,11 @@ defmodule LazyDoc.TaskTest do
          ]}
       ]
 
-    name_extraction = LazyDoc.extract_names(ast)
+    name_extraction =
+      LazyDoc.extract_names(ast)
+      |> Enum.map(fn {:module, mod, mod, _code_mod, functions} ->
+        {:module, mod, mod, functions}
+      end)
 
     assert name_extraction == expected_names
 
@@ -126,10 +130,10 @@ defmodule LazyDoc.TaskTest do
 
     name_module =
       LazyDoc.extract_names(ast)
-      |> Enum.map(fn {:module, module_name, module_ast, functions} ->
-        {module_name |> Module.concat(), module_ast, LazyDoc.join_code_from_clauses(functions)}
+      |> Enum.map(fn {:module, module_name, module_ast, code_mod, functions} ->
+        {module_name |> Module.concat(), module_ast, code_mod, LazyDoc.join_code_from_clauses(functions)}
       end)
-      |> Enum.find(fn {module_name, _module_ast, _functions} ->
+      |> Enum.find(fn {module_name, _module_ast, _code_mod, _functions} ->
         module_name == LazyDoc.ExampleModule
       end)
 

--- a/test/lazy_doc/task_test.exs
+++ b/test/lazy_doc/task_test.exs
@@ -131,7 +131,8 @@ defmodule LazyDoc.TaskTest do
     name_module =
       LazyDoc.extract_names(ast)
       |> Enum.map(fn {:module, module_name, module_ast, code_mod, functions} ->
-        {module_name |> Module.concat(), module_ast, code_mod, LazyDoc.join_code_from_clauses(functions)}
+        {module_name |> Module.concat(), module_ast, code_mod,
+         LazyDoc.join_code_from_clauses(functions)}
       end)
       |> Enum.find(fn {module_name, _module_ast, _code_mod, _functions} ->
         module_name == LazyDoc.ExampleModule


### PR DESCRIPTION
This PR

- [X] Modifies the extraction of AST to allow `@moduledoc`
- [X] Implements the `lazy_doc.check` to detect undocumented modules.
- [X] Implements `@moduledoc` insertion in the AST
- [X] Creates an option to customize `@moduledoc` prompt.
- [X] Adds a formatter option to fix format when write the AST to the file.
- [X] Fixes tests 