### PR TITLE
Feature/add external docs config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ npm-debug.log
 
 # Cldr
 /priv/cldr/*
+
+.vscode

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ _ = """
 """
 
 config :lazy_doc,
-  external_docs: false,
+  external_docs: true,
   patterns: [
     ~r"^lib/[a-zA-Z_]+(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
   ],
@@ -18,6 +18,6 @@ config :lazy_doc,
   line_length: 98,
   provider: {GithubAi, :gpt_4o_mini, [max_tokens: 2048, top_p: 1, temperature: 1]},
   custom_function_prompt:
-    ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n@doc """\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\n"""\n\nFunction to document:\n),
+    ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\nFunction to document:\n),
   custom_module_prompt:
     ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc.\n"""\n\nModule to document:\n)

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,7 @@ _ = """
 config :lazy_doc,
   external_docs: true,
   patterns: [
-    ~r"^lib/[a-zA-Z_]+(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
+    ~r"^lib(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
   ],
   max_retries: 3,
   receive_timeout: 15_000,

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,6 +9,7 @@ _ = """
 """
 
 config :lazy_doc,
+  external_docs: false,
   patterns: [
     ~r"^lib/[a-zA-Z_]+(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
   ],

--- a/lazy_doc/lazy_doc/join_code_from_clauses.md
+++ b/lazy_doc/lazy_doc/join_code_from_clauses.md
@@ -1,0 +1,9 @@
+## Parameters
+
+- names - a list of tuples containing type and name/code pairs to process for join code generation.
+
+## Description
+Processes the list of name/code tuples to generate a list of joined code based on the naming criteria defined within the function.
+
+## Returns
+A list of tuples representing the joined code or original tuples where applicable.

--- a/lazy_doc/mix/tasks/lazy_doc/docs_to_module_doc_node.md
+++ b/lazy_doc/mix/tasks/lazy_doc/docs_to_module_doc_node.md
@@ -1,0 +1,11 @@
+## Parameters
+
+- docs - the documentation string to be processed.
+- acc_ast - the accumulated abstract syntax tree (AST) to which the new documentation will be added.
+- module_ast - the abstract syntax tree (AST) of the module that contains the documentation.
+
+## Description
+ Processes the documentation string and integrates it into the module's AST.
+
+## Returns
+ The updated accumulated abstract syntax tree (AST) after inserting the documentation node.

--- a/lazy_doc/mix/tasks/lazy_doc/insert_nodes_in_module.md
+++ b/lazy_doc/mix/tasks/lazy_doc/insert_nodes_in_module.md
@@ -1,0 +1,17 @@
+## Parameters
+
+- module - the module where nodes will be inserted.
+- module_ast - the abstract syntax tree (AST) of the module.
+- functions - a list of functions to process.
+- final_prompt - the final prompt string to be sent for generating documentation.
+- provider_mod - the module responsible for handling requests.
+- model_text - the model text to use in the request.
+- token - the authentication token for the request.
+- params - parameters to be included in the request.
+- acc - an accumulator used to store intermediate results.
+
+## Description
+Handles the insertion of documentation nodes into a module by processing a list of functions and retrieving documentation based on prompts provided to a designated provider.
+
+## Returns
+the modified abstract syntax tree (AST) with the newly inserted documentation nodes.

--- a/lazy_doc/mix/tasks/lazy_doc/proccess_files.md
+++ b/lazy_doc/mix/tasks/lazy_doc/proccess_files.md
@@ -1,0 +1,9 @@
+## Parameters
+
+- entries - a list of entry structures containing modules, functions, and associated AST.
+
+## Description
+Processes a list of entries, generating documentation for modules and functions by querying a provider.
+
+## Returns
+Nothing; it writes formatted documentation to files based on the provided entries.

--- a/lib/lazy_doc.ex
+++ b/lib/lazy_doc.ex
@@ -26,7 +26,7 @@ defmodule LazyDoc do
   def extract_data_from_files() do
     patterns =
       Application.get_env(:lazy_doc, :patterns, [
-        ~r"^lib/[a-zA-Z_]+(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
+        ~r"^lib(?:/[a-zA-Z_]+)*/[a-zA-Z_]+\.ex$"
       ])
 
     Path.wildcard(@global_path)
@@ -88,16 +88,7 @@ defmodule LazyDoc do
     end)
   end
 
-  @doc """
-  Parameters
-
-  names - a list of tuples where each tuple contains a type and a value. The type indicates the kind of element (e.g., :function) and the value is related to that type.
-  Description
-   Joins code from function clauses based on their names, merging the code of functions with the same name.
-
-  Returns
-   a list of elements where functions with the same name are combined into a single tuple with their code concatenated.
-  """
+  @doc File.read!("lazy_doc/lazy_doc/join_code_from_clauses.md")
   def join_code_from_clauses(names) do
     join_code_from_clauses(names, [])
   end

--- a/lib/mix/tasks/lazy_doc.ex
+++ b/lib/mix/tasks/lazy_doc.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.LazyDoc do
   require Logger
   use Mix.Task
 
-  @default_function_prompt ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n@doc """\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\n"""\n\nFunction to document:\n)
+  @default_function_prompt ~s(You should describe the parameters based on the spec given and give a small description of the following function.\n\nPlease do it in the following format given as an example, important do not return the header of the function, do not return a explanation of the function, your output must be only the docs in the following format.\n\n## Parameters\n\n- transaction_id - foreign key of the Transactions table.\n## Description\n Performs a search in the database\n\n## Returns\n the Transaction corresponding to transaction_id\n\nFunction to document:\n)
 
   @default_module_prompt ~s(You should describe what this module does based on the code given.\n\n Please do it in the following format given as an example, important do not return the code of the module, your output must be only the docs in the following format.\n\n@moduledoc """\n\n ## Main functionality\n\n The module GithubAi provides a way of communicating with Github AI API.\n\n ## Description\n\n It implements the behavior Provider a standard way to use a provider in LazyDoc.\n"""\n\nModule to document:\n)
 
@@ -232,28 +232,9 @@ defmodule Mix.Tasks.LazyDoc do
     end)
   end
 
-  @doc """
-
-  Parameters
-
-  _module - the module to which the nodes will be inserted.
-  module_ast - the abstract syntax tree of the module.
-  functions - a list of functions to be processed.
-  final_prompt - a string prompt to be appended to each function's prompt.
-  provider_mod - the module responsible for making requests to the provider.
-  model_text - the text representation of the model used in the request.
-  token - the authentication token for the provider.
-  acc - the accumulator for building the updated abstract syntax tree.
-
-  Description
-   Inserts nodes into a module based on provided functions and prompts.
-
-  Returns
-   the updated abstract syntax tree after processing the functions.
-
-  """
+  @doc File.read!("lazy_doc/mix/tasks/lazy_doc/insert_nodes_in_module.md")
   def insert_nodes_in_module(
-        {_module, module_ast, functions},
+        {module, module_ast, functions},
         final_prompt,
         provider_mod,
         model_text,
@@ -261,6 +242,8 @@ defmodule Mix.Tasks.LazyDoc do
         params,
         acc
       ) do
+    is_external_docs = Application.get_env(:lazy_doc, :external_docs, false)
+
     Enum.reduce(functions, acc, fn {:function, {function_atom, function_stringified}}, acc_ast ->
       function_prompt = final_prompt <> function_stringified
 
@@ -270,14 +253,36 @@ defmodule Mix.Tasks.LazyDoc do
 
       docs = Provider.get_docs_from_response(provider_mod, response)
 
-      ok? = docs_are_ok?(docs)
+      docs =
+        if is_external_docs do
+          path =
+            to_string(module.module_info(:compile)[:source])
+            |> String.split("/lib")
+            |> Enum.at(1)
+            |> then(fn path -> "lazy_doc#{path}" end)
+            |> String.replace(
+              ".ex",
+              ""
+            )
 
-      docs_to_node(ok?, docs, acc_ast, function_atom, module_ast)
+          File.mkdir_p(path)
+
+          file = "#{path}/#{function_atom}.md"
+
+          File.write!(file, docs)
+
+          "@doc File.read!(\"#{file}\")"
+        else
+          ~s(@doc """\n\n#{docs}\n\n""")
+        end
+        |> dbg()
+
+      docs_to_node(docs, acc_ast, function_atom, module_ast)
     end)
   end
 
   @doc false
-  def docs_to_node(true, docs, acc_ast, function_atom, module_ast) do
+  def docs_to_node(docs, acc_ast, function_atom, module_ast) do
     result =
       Code.string_to_quoted_with_comments(docs,
         literal_encoder: &{:ok, {:__block__, &2, [&1]}},
@@ -295,13 +300,6 @@ defmodule Mix.Tasks.LazyDoc do
     end
   end
 
-  @doc false
-  def docs_to_node(false, docs, _ast, _function_atom) do
-    Logger.error(
-      "docs are in a wrong format review your prompt\n\n this was returned by the AI: #{docs}"
-    )
-  end
-
   @doc """
 
   ## Parameters
@@ -317,15 +315,6 @@ defmodule Mix.Tasks.LazyDoc do
    the updated accumulator AST after inserting the new documentation.
   """
   def docs_to_module_doc_node(docs, acc_ast, module_ast) do
-    docs_to_module_doc_node(
-      Application.get_env(:lazy_doc, :custom_module_prompt, false),
-      docs,
-      acc_ast,
-      module_ast
-    )
-  end
-
-  defp docs_to_module_doc_node(true, docs, acc_ast, module_ast) do
     result =
       Code.string_to_quoted_with_comments(docs,
         literal_encoder: &{:ok, {:__block__, &2, [&1]}},
@@ -341,9 +330,6 @@ defmodule Mix.Tasks.LazyDoc do
         Logger.error("Cannot parse the response as an Elixir AST: #{inspect(reason)}")
         acc_ast
     end
-  end
-
-  defp docs_to_module_doc_node(false, docs, acc_ast, module_ast) do
   end
 
   @doc """

--- a/lib/mix/tasks/lazy_doc.ex
+++ b/lib/mix/tasks/lazy_doc.ex
@@ -168,17 +168,7 @@ defmodule Mix.Tasks.LazyDoc do
     new_ast
   end
 
-  @doc """
-
-  Parameters
-
-  entries - a list of entry structures containing functions and associated ASTs.
-  Description
-   A list of entries to process, transforming functions based on model responses.
-
-  Returns
-   None
-  """
+  @doc File.read!("lazy_doc/mix/tasks/lazy_doc/proccess_files.md")
   def proccess_files(entries) do
     {provider_mod, model, params} = Application.get_env(:lazy_doc, :provider)
 

--- a/lib/mix/tasks/lazy_doc.ex
+++ b/lib/mix/tasks/lazy_doc.ex
@@ -317,6 +317,15 @@ defmodule Mix.Tasks.LazyDoc do
    the updated accumulator AST after inserting the new documentation.
   """
   def docs_to_module_doc_node(docs, acc_ast, module_ast) do
+    docs_to_module_doc_node(
+      Application.get_env(:lazy_doc, :custom_module_prompt, false),
+      docs,
+      acc_ast,
+      module_ast
+    )
+  end
+
+  defp docs_to_module_doc_node(true, docs, acc_ast, module_ast) do
     result =
       Code.string_to_quoted_with_comments(docs,
         literal_encoder: &{:ok, {:__block__, &2, [&1]}},
@@ -332,6 +341,9 @@ defmodule Mix.Tasks.LazyDoc do
         Logger.error("Cannot parse the response as an Elixir AST: #{inspect(reason)}")
         acc_ast
     end
+  end
+
+  defp docs_to_module_doc_node(false, docs, acc_ast, module_ast) do
   end
 
   @doc """

--- a/test/lazy_doc/task_test.exs
+++ b/test/lazy_doc/task_test.exs
@@ -175,7 +175,8 @@ defmodule LazyDoc.TaskTest do
 
     function_name = :hihi
 
-    new_ast = TaskLazyDoc.docs_to_node(true, docs, ast, function_name, [:LazyDoc, :ExampleModule])
+    ## Expects always elixir @doc valid annotation
+    new_ast = TaskLazyDoc.docs_to_node(docs, ast, function_name, [:LazyDoc, :ExampleModule])
 
     ## Check if the AST has @doc node before the :hihi node
 


### PR DESCRIPTION
- [ ] Change the default function prompt to make the AI generate always markdown and when it is not `external_docs` mode add `@doc` syntax to the string.
- [ ] Update `def docs_to_module_doc_node` to save the output to a file at `lazy_doc/{module/path/filename.md` as follows:

```elixir
defmodule LazyDoc.Providers.GithubAI do
    @doc File.read!("lazy_doc/lazy_doc/providers/github_ai/request_promt.md")
    def request_prompt(prompt, model, token, params \\ []) do
     req_query(prompt, model, token, params)
     |> Req.post()
  end
end
```